### PR TITLE
Only check for WindowsComboBoxUI when on Windows

### DIFF
--- a/designer/src/com/android/tools/idea/common/property/editors/EnumEditor.java
+++ b/designer/src/com/android/tools/idea/common/property/editors/EnumEditor.java
@@ -35,7 +35,6 @@ import com.intellij.ui.ColoredListCellRenderer;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.scale.JBUIScale;
 import com.intellij.util.ui.JBUI;
-import com.sun.java.swing.plaf.windows.WindowsComboBoxUI;
 import org.jetbrains.android.dom.attrs.AttributeDefinition;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -53,6 +52,7 @@ import java.awt.event.FocusEvent;
 import java.awt.event.KeyEvent;
 import java.util.List;
 import java.util.Objects;
+import org.apache.commons.lang3.SystemUtils;
 
 abstract public class EnumEditor extends BaseComponentEditor implements NlComponentEditor {
   private EnumSupport myEnumSupport;
@@ -466,17 +466,20 @@ abstract public class EnumEditor extends BaseComponentEditor implements NlCompon
 
     @Override
     public void setUI(ComboBoxUI ui) {
-      myUseDarculaUI = !(ui instanceof WindowsComboBoxUI) && !ApplicationManager.getApplication().isUnitTestMode();
-      if (myUseDarculaUI) {
-        // There are multiple reasons for hardcoding the ComboBoxUI here:
-        // 1) Some LAF will draw a beveled border which does not look good in the table grid.
-        // 2) In the inspector we would like the reference editor and the combo boxes to have a similar width.
-        //    This is very hard unless you can control the UI.
-        // Note: forcing the Darcula UI does not imply dark colors.
-        ui = new CustomDarculaComboBoxUI(this);
+      // Only check for WindowsComboBoxUI when on Windows
+      if (SystemUtils.IS_OS_WINDOWS) {
+        myUseDarculaUI = !(ui instanceof com.sun.java.swing.plaf.windows.WindowsComboBoxUI) && !ApplicationManager.getApplication().isUnitTestMode();
+        if (myUseDarculaUI) {
+          // There are multiple reasons for hardcoding the ComboBoxUI here:
+          // 1) Some LAF will draw a beveled border which does not look good in the table grid.
+          // 2) In the inspector we would like the reference editor and the combo boxes to have a similar width.
+          //    This is very hard unless you can control the UI.
+          // Note: forcing the Darcula UI does not imply dark colors.
+          ui = new CustomDarculaComboBoxUI(this);
+        }
+        super.setUI(ui);
+        setBorders();
       }
-      super.setUI(ui);
-      setBorders();
     }
   }
 


### PR DESCRIPTION
On newer versions of jdk on other operating systems, WindowsComboBoxUI doesn't exist.
This causes the error below:
```
java.lang.NoClassDefFoundError: com/sun/java/swing/plaf/windows/WindowsComboBoxUI
	at com.android.tools.idea.common.property.editors.EnumEditor$CustomComboBox.setUI(EnumEditor.java:470)
	at java.desktop/javax.swing.JComboBox.updateUI(JComboBox.java:277)
	at java.desktop/javax.swing.JComboBox.init(JComboBox.java:236)
	at java.desktop/javax.swing.JComboBox.<init>(JComboBox.java:230)
	at com.intellij.openapi.ui.ComboBoxWithWidePopup.<init>(ComboBoxWithWidePopup.java:15)
	at com.intellij.openapi.ui.ComboBox.<init>(ComboBox.java:44)
	at com.android.tools.idea.common.property.editors.EnumEditor$CustomComboBox.<init>(EnumEditor.java:440)
	at com.android.tools.idea.uibuilder.property.editors.NlEnumEditor.createForInspectorWithBrowseButton(NlEnumEditor.java:45)
	at com.android.tools.idea.uibuilder.property.inspector.IdInspectorProvider$IdInspectorComponent.<init>(IdInspectorProvider.java:96)
	at com.android.tools.idea.uibuilder.property.inspector.IdInspectorProvider.createCustomInspector(IdInspectorProvider.java:74)
	at com.android.tools.idea.uibuilder.property.inspector.IdInspectorProvider.createCustomInspector(IdInspectorProvider.java:39)
	at com.android.tools.idea.common.property.inspector.InspectorProviders.createInspectorComponents(InspectorProviders.java:54)
	at com.android.tools.idea.common.property.inspector.InspectorPanel.setComponent(InspectorPanel.java:260)
	at com.android.tools.idea.uibuilder.property.NlPropertiesPanel.setItems(NlPropertiesPanel.java:281)
	at com.android.tools.idea.common.property.PropertiesManager.lambda$null$0(PropertiesManager.java:247)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:313)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:770)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:389)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:740)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:878)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:827)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:466)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:704)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:465)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
Caused by: java.lang.ClassNotFoundException: com.sun.java.swing.plaf.windows.WindowsComboBoxUI PluginClassLoader[org.jetbrains.android, 10.3.4] com.intellij.ide.plugins.cl.PluginClassLoader@2325d49
	at com.intellij.ide.plugins.cl.PluginClassLoader.loadClass(PluginClassLoader.java:75)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	... 33 more
```